### PR TITLE
Fix LABEL_REPEATED equals bug

### DIFF
--- a/tools/sisyphus-protoc/src/main/kotlin/com/bybutter/sisyphus/protobuf/compiler/core/generator/MessageImplementationGenerator.kt
+++ b/tools/sisyphus-protoc/src/main/kotlin/com/bybutter/sisyphus/protobuf/compiler/core/generator/MessageImplementationGenerator.kt
@@ -539,7 +539,7 @@ class MessageFieldEqualsFunctionGenerator : GroupedGenerator<MessageEqualsFuncti
                 }
                 DescriptorProtos.FieldDescriptorProto.Label.LABEL_REPEATED -> {
                     addStatement(
-                        "if (%N.%M(other.%N)) return true", state.descriptor.name(),
+                        "if (!%N.%M(other.%N)) return false", state.descriptor.name(),
                         RuntimeMethods.CONTENT_EQUALS, state.descriptor.name()
                     )
                 }


### PR DESCRIPTION
Incorrect list comparison in Message.equalsMessage()