### PR TITLE
Add grpc client register with proxy

### DIFF
--- a/middleware/sisyphus-grpc-client/src/main/kotlin/com/bybutter/sisyphus/middleware/grpc/property/GrpcChannelProperty.kt
+++ b/middleware/sisyphus-grpc-client/src/main/kotlin/com/bybutter/sisyphus/middleware/grpc/property/GrpcChannelProperty.kt
@@ -1,0 +1,10 @@
+package com.bybutter.sisyphus.middleware.grpc.property
+
+import io.grpc.CallOptions
+
+data class GrpcChannelProperty(
+    val name: String,
+    val target: String,
+    val services: Set<Class<*>>,
+    val options: CallOptions = CallOptions.DEFAULT
+)

--- a/middleware/sisyphus-grpc-client/src/main/kotlin/com/bybutter/sisyphus/middleware/grpc/property/PropertyClientRepository.kt
+++ b/middleware/sisyphus-grpc-client/src/main/kotlin/com/bybutter/sisyphus/middleware/grpc/property/PropertyClientRepository.kt
@@ -1,8 +1,12 @@
-package com.bybutter.sisyphus.middleware.grpc
+package com.bybutter.sisyphus.middleware.grpc.property
 
+import com.bybutter.sisyphus.middleware.grpc.ChannelBuilderInterceptor
+import com.bybutter.sisyphus.middleware.grpc.ClientBuilderInterceptor
+import com.bybutter.sisyphus.middleware.grpc.ClientRegistrar
+import com.bybutter.sisyphus.middleware.grpc.ClientRepository
+import com.bybutter.sisyphus.middleware.grpc.ManagedChannelLifecycle
 import com.bybutter.sisyphus.rpc.CallOptionsInterceptor
 import com.bybutter.sisyphus.spring.BeanUtils
-import io.grpc.CallOptions
 import io.grpc.ClientInterceptor
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
 import org.springframework.beans.factory.getBean
@@ -11,7 +15,7 @@ import org.springframework.beans.factory.support.AbstractBeanDefinition
 import org.springframework.beans.factory.support.BeanDefinitionBuilder
 import org.springframework.core.env.Environment
 
-class RemoteClientRepository : ClientRepository {
+class PropertyClientRepository : ClientRepository {
 
     override var order: Int = Int.MAX_VALUE - 1000
 
@@ -37,7 +41,7 @@ class RemoteClientRepository : ClientRepository {
                 val client = getClientFromService(service)
                 val clientBeanDefinition = BeanDefinitionBuilder.genericBeanDefinition(client as Class<Any>) {
                     interceptStub(
-                        createGrpcClient(client, channel, optionsInterceptors.values, CallOptions.DEFAULT),
+                        createGrpcClient(client, channel, optionsInterceptors.values, property.options),
                         builderInterceptors.values,
                         clientInterceptors.values
                     )

--- a/middleware/sisyphus-grpc-client/src/main/kotlin/com/bybutter/sisyphus/middleware/grpc/proxy/GrpcClientProxy.kt
+++ b/middleware/sisyphus-grpc-client/src/main/kotlin/com/bybutter/sisyphus/middleware/grpc/proxy/GrpcClientProxy.kt
@@ -1,8 +1,8 @@
-package com.bybutter.sisyphus.middleware.grpc
+package com.bybutter.sisyphus.middleware.grpc.proxy
 
 import io.grpc.CallOptions
 
-data class GrpcChannelProperty(
+class GrpcClientProxy(
     val name: String,
     val target: String,
     val services: Set<Class<*>>,

--- a/middleware/sisyphus-grpc-client/src/main/kotlin/com/bybutter/sisyphus/middleware/grpc/proxy/ProxyClientRepository.kt
+++ b/middleware/sisyphus-grpc-client/src/main/kotlin/com/bybutter/sisyphus/middleware/grpc/proxy/ProxyClientRepository.kt
@@ -1,0 +1,55 @@
+package com.bybutter.sisyphus.middleware.grpc.proxy
+
+import com.bybutter.sisyphus.middleware.grpc.ChannelBuilderInterceptor
+import com.bybutter.sisyphus.middleware.grpc.ClientBuilderInterceptor
+import com.bybutter.sisyphus.middleware.grpc.ClientRegistrar
+import com.bybutter.sisyphus.middleware.grpc.ClientRepository
+import com.bybutter.sisyphus.middleware.grpc.ManagedChannelLifecycle
+import com.bybutter.sisyphus.rpc.CallOptionsInterceptor
+import com.bybutter.sisyphus.spring.BeanUtils
+import io.grpc.ClientInterceptor
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.beans.factory.getBean
+import org.springframework.beans.factory.support.AbstractBeanDefinition
+import org.springframework.beans.factory.support.BeanDefinitionBuilder
+import org.springframework.core.env.Environment
+import org.springframework.stereotype.Component
+
+@Component
+class ProxyClientRepository : ClientRepository {
+
+    override var order: Int = Int.MAX_VALUE - 1000
+
+    override fun listClientBeanDefinition(
+        beanFactory: ConfigurableListableBeanFactory,
+        environment: Environment
+    ): List<AbstractBeanDefinition> {
+        val grpcClientProxies = BeanUtils.getSortedBeans(beanFactory, GrpcClientProxy::class.java)
+
+        if (grpcClientProxies.values.isEmpty()) return arrayListOf()
+        val beanDefinitionList = arrayListOf<AbstractBeanDefinition>()
+        val channelBuilderInterceptors = BeanUtils.getSortedBeans(beanFactory, ChannelBuilderInterceptor::class.java)
+        val builderInterceptors = BeanUtils.getSortedBeans(beanFactory, ClientBuilderInterceptor::class.java)
+        val clientInterceptors = BeanUtils.getSortedBeans(beanFactory, ClientInterceptor::class.java)
+        val optionsInterceptors = BeanUtils.getSortedBeans(beanFactory, CallOptionsInterceptor::class.java)
+        val managedChannelLifecycle =
+            beanFactory.getBean<ManagedChannelLifecycle>(ClientRegistrar.QUALIFIER_AUTO_CONFIGURED_GRPC_CHANNEL_LIFECYCLE)
+
+        for (grpcClientProxy in grpcClientProxies.values) {
+            val channel = createGrpcChannel(grpcClientProxy.target, channelBuilderInterceptors.values, managedChannelLifecycle)
+            beanFactory.registerSingleton(grpcClientProxy.name, channel)
+            for (service in grpcClientProxy.services) {
+                val client = getClientFromService(service)
+                val clientBeanDefinition = BeanDefinitionBuilder.genericBeanDefinition(client as Class<Any>) {
+                    interceptStub(
+                        createGrpcClient(client, channel, optionsInterceptors.values, grpcClientProxy.options),
+                        builderInterceptors.values,
+                        clientInterceptors.values
+                    )
+                }
+                beanDefinitionList.add(clientBeanDefinition.beanDefinition)
+            }
+        }
+        return beanDefinitionList
+    }
+}

--- a/middleware/sisyphus-grpc-client/src/main/resources/META-INF/services/com.bybutter.sisyphus.middleware.grpc.ClientRepository
+++ b/middleware/sisyphus-grpc-client/src/main/resources/META-INF/services/com.bybutter.sisyphus.middleware.grpc.ClientRepository
@@ -1,1 +1,1 @@
-com.bybutter.sisyphus.middleware.grpc.RemoteClientRepository
+com.bybutter.sisyphus.middleware.grpc.property.PropertyClientRepository

--- a/middleware/sisyphus-grpc-client/src/main/resources/META-INF/services/com.bybutter.sisyphus.middleware.grpc.ClientRepository
+++ b/middleware/sisyphus-grpc-client/src/main/resources/META-INF/services/com.bybutter.sisyphus.middleware.grpc.ClientRepository
@@ -1,1 +1,2 @@
 com.bybutter.sisyphus.middleware.grpc.property.PropertyClientRepository
+com.bybutter.sisyphus.middleware.grpc.proxy.ProxyClientRepository


### PR DESCRIPTION
We can use grpc client register such as：
```
@Configuration
class ClientConfig {

    @Bean
    fun userClient(): GrpcClientProxy {
        return GrpcClientProxy(
            "userClient",
            "user-host:9090",
            services,
            CallOptions.DEFAULT,
        )
    }
}
